### PR TITLE
Move cert providers

### DIFF
--- a/content/modules/ROOT/pages/01-create-an-image.adoc
+++ b/content/modules/ROOT/pages/01-create-an-image.adoc
@@ -66,7 +66,7 @@ any other application container. Let’s build this image with
 
 [source,bash,run,subs=attributes+]
 ----
-podman build -t builder.{guid}.{domain}:5000/test-bootc .
+podman build -t builder-{guid}.{domain}/test-bootc .
 ----
 
 Once built, bootc images use OCI standard container registries for
@@ -76,7 +76,7 @@ and more.
 
 [source,bash,run,subs=attributes+]
 ----
-podman push builder.{guid}.{domain}:5000/test-bootc
+podman push builder-{guid}.{domain}/test-bootc
 ----
 
 This is really all that is needed for a simple web server! We can add

--- a/content/modules/ROOT/pages/02-deploy-an-image.adoc
+++ b/content/modules/ROOT/pages/02-deploy-an-image.adoc
@@ -27,7 +27,7 @@ podman run --rm --privileged \
         registry.redhat.io/rhel10/bootc-image-builder:10.0 \
         --type qcow2 \
         --config config.json \
-         builder.{guid}.{domain}:5000/test-bootc
+         builder-{guid}.{domain}/test-bootc
 ----
 
 This tool is a containerized version of image builder that includes the

--- a/content/modules/ROOT/pages/03-add-software-to-image.adoc
+++ b/content/modules/ROOT/pages/03-add-software-to-image.adoc
@@ -31,7 +31,7 @@ With our changes in the Containerfile, we can re-run the
 
 [source,bash,run,subs=attributes+]
 ----
-podman build -t builder.{guid}.{domain}:5000/test-bootc .
+podman build -t builder-{guid}.{domain}/test-bootc .
 ----
 
 Since the `+RUN+` command to install software happens after the `+ADD+`
@@ -47,7 +47,7 @@ registry.
 
 [source,bash,run,subs=attributes+]
 ----
-podman push builder.{guid}.{domain}:5000/test-bootc
+podman push builder-{guid}.{domain}/test-bootc
 ----
 
 In the next step, we’ll look at how to update a running system from the

--- a/setup-automation/setup-builder.sh
+++ b/setup-automation/setup-builder.sh
@@ -31,7 +31,7 @@ set +x
 certbot certonly --eab-kid "${ZEROSSL_EAB_KEY_ID}" --eab-hmac-key "${ZEROSSL_HMAC_KEY}" --server "https://acme.zerossl.com/v2/DV90" --standalone --preferred-challenges http -d builder-"${GUID}"."${DOMAIN}" --non-interactive --agree-tos -m trackbot@instruqt.com -v
 
 # Don't leak password to users
-#rm /var/log/letsencrypt/letsencrypt.log
+rm /var/log/letsencrypt/letsencrypt.log
 
 # reset tracing
 set -x

--- a/setup-automation/setup-builder.sh
+++ b/setup-automation/setup-builder.sh
@@ -28,10 +28,10 @@ dnf install -y certbot
 
 # request certificates but don't log keys
 set +x
-certbot certonly --eab-kid "${ZEROSSL_EAB_KEY_ID}" --eab-hmac-key "${ZEROSSL_HMAC_KEY}" --server "https://acme.zerossl.com/v2/DV90" --standalone --preferred-challenges http -d builder."${GUID}"."${DOMAIN}" --non-interactive --agree-tos -m trackbot@instruqt.com -v
+certbot certonly --eab-kid "${ZEROSSL_EAB_KEY_ID}" --eab-hmac-key "${ZEROSSL_HMAC_KEY}" --server "https://acme.zerossl.com/v2/DV90" --standalone --preferred-challenges http -d builder-"${GUID}"."${DOMAIN}" --non-interactive --agree-tos -m trackbot@instruqt.com -v
 
 # Don't leak password to users
-rm /var/log/letsencrypt/letsencrypt.log
+#rm /var/log/letsencrypt/letsencrypt.log
 
 # reset tracing
 set -x
@@ -40,8 +40,8 @@ set -x
 podman run --privileged -d \
   --name registry \
   -p 5000:5000 \
-  -v /etc/letsencrypt/live/builder."${GUID}"."${DOMAIN}"/fullchain.pem:/certs/fullchain.pem \
-  -v /etc/letsencrypt/live/builder."${GUID}"."${DOMAIN}"/privkey.pem:/certs/privkey.pem \
+  -v /etc/letsencrypt/live/builder-"${GUID}"."${DOMAIN}"/fullchain.pem:/certs/fullchain.pem \
+  -v /etc/letsencrypt/live/builder-"${GUID}"."${DOMAIN}"/privkey.pem:/certs/privkey.pem \
   -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/fullchain.pem \
   -e REGISTRY_HTTP_TLS_KEY=/certs/privkey.pem \
   quay.io/mmicene/registry:2
@@ -166,6 +166,7 @@ EOF
 
 # Add name based resolution for internal IPs
 echo "10.0.2.2 builder.${GUID}.${DOMAIN}" >> /etc/hosts
+echo "10.0.2.2 builder-${GUID}.${DOMAIN}" >> /etc/hosts
 cp /etc/hosts ~/etc/hosts
 
 # Script that manages the VM SSH session tab

--- a/setup-automation/setup-builder.sh
+++ b/setup-automation/setup-builder.sh
@@ -39,6 +39,7 @@ set -x
 # run a local registry with the provided certs
 podman run --privileged -d \
   --name registry \
+  -p 443:5000 \
   -p 5000:5000 \
   -v /etc/letsencrypt/live/builder-"${GUID}"."${DOMAIN}"/fullchain.pem:/certs/fullchain.pem \
   -v /etc/letsencrypt/live/builder-"${GUID}"."${DOMAIN}"/privkey.pem:/certs/privkey.pem \


### PR DESCRIPTION
Setup changes:
- Move to host-guid URL formatting for CA subdomain issues
- Move registry to standard HTTPS port

Exercise changes:
- Correct URL and port for podman commands based on new setup